### PR TITLE
Release 1.0

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         node-version: [ 14, 16 ]
       fail-fast: false
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         node-version: [ 14, 16 ]
       fail-fast: false
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         node-version: [ 14, 16 ]
       fail-fast: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
+# CHANGE LOG
 
 #### 1.N.N - YYYY-MM-DD
+
+
+#### 1.0.0 - 2022-04-25
+
+- tinydns: print unparsable line before throwing
+- fix(dns-zone): update import syntax for ESM RR
 
 
 #### 0.9.0 - 2022-04-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@
 
 #### 1.0.0 - 2022-04-25
 
-- tinydns: print unparsable line before throwing
 - fix(dns-zone): update import syntax for ESM RR
+- feat(bin/dns-zone): when -e=tinydns fails, show entry
+- feat(bin/dns-zone): usage caller specifies exit code
+- feat(bind): print a . for every 500 RRs parsed
+- feat(tinydns): print unparsable line before throwing
+- test(dns-zone): add help and example.com tests
+- test(dns-zone): import tinydns zone, export as mara
 
 
 #### 0.9.0 - 2022-04-19

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Import and export DNS data to and from common nameserver formats. Normalize, val
 
 
 ````
-➜ ./bin/dns-zone -h
+➜ ./bin/dns-zone.js -h
 
  +-+-+-+ +-+-+-+-+
  |D|N|S| |Z|O|N|E|
@@ -43,14 +43,14 @@ Misc
 
 Examples
 
-  1. BIND file to human     ./bin/dns-zone -i bind -f isi.edu
-  2. BIND file to tinydns   ./bin/dns-zone -i bind -f isi.edu -e tinydns
-  3. tinydns file to BIND   ./bin/dns-zone -i tinydns -f data -e bind
+  1. BIND file to human     ./bin/dns-zone.js -i bind -f isi.edu
+  2. BIND file to tinydns   ./bin/dns-zone.js -i bind -f isi.edu -e tinydns
+  3. tinydns file to BIND   ./bin/dns-zone.js -i tinydns -f data -e bind
 
   Project home: https://github.com/NicTool/dns-zone
 ````
 
-## bin/dns-zone
+## bin/dns-zone.js
 
 #### import from STDIN to human
 

--- a/bin/dns-zone.js
+++ b/bin/dns-zone.js
@@ -9,6 +9,7 @@ import cmdLineArgs from 'command-line-args'
 import cmdLineUsage from 'command-line-usage'
 
 import ZONE         from '../lib/zone.js'
+import * as dz      from '../index.js'
 import * as bind    from '../lib/bind.js'
 import * as tinydns from '../lib/tinydns.js'
 import * as maradns from '../lib/maradns.js'
@@ -40,11 +41,12 @@ Object.assign(maradns.zoneOpts, optsObj)
 if (opts.verbose) console.error(bind.zoneOpts)
 
 ingestZoneData()
-  .then(r => {
+  .then(async r => {
     switch (r.type) {
       case 'tinydns':
         return tinydns.parseData(r.data).then(checkZone)
       case 'maradns':
+        maradns.zoneOpts.serial = await dz.serialByFileStat(opts.file)
         return maradns.parseZoneFile(r.data).then(checkZone)
       default:
         return bind.parseZoneFile(r.data).then(checkZone)

--- a/bin/dns-zone.js
+++ b/bin/dns-zone.js
@@ -13,7 +13,7 @@ import * as bind    from '../lib/bind.js'
 import * as tinydns from '../lib/tinydns.js'
 import * as maradns from '../lib/maradns.js'
 
-import RR from 'dns-resource-record'
+import * as RR from 'dns-resource-record'
 
 const rr = new RR.A(null)
 

--- a/bin/dns-zone.js
+++ b/bin/dns-zone.js
@@ -8,7 +8,7 @@ import chalk from 'chalk'
 import cmdLineArgs from 'command-line-args'
 import cmdLineUsage from 'command-line-usage'
 
-import * as zf      from '../index.js'
+import ZONE         from '../lib/zone.js'
 import * as bind    from '../lib/bind.js'
 import * as tinydns from '../lib/tinydns.js'
 import * as maradns from '../lib/maradns.js'
@@ -59,7 +59,7 @@ ingestZoneData()
 function checkZone (zoneArray) {
   return new Promise((resolve, reject) => {
     try {
-      new zf.ZONE({
+      new ZONE({
         ttl: optsObj.ttl, origin: optsObj.origin, RR: zoneArray,
       })
       // console.log(z)

--- a/bin/dns-zone.js
+++ b/bin/dns-zone.js
@@ -1,4 +1,4 @@
-#!node
+#!/usr/local/bin/node
 
 import fs   from 'fs/promises'
 import path from 'path'
@@ -283,7 +283,14 @@ function toBind (zoneArray, origin) {
 function toTinydns (zoneArray) {
   for (const rr of zoneArray) {
     if (rr === os.EOL) continue
-    process.stdout.write(rr.toTinydns())
+    if (rr.$TTL || rr.$ORIGIN) continue
+    try {
+      process.stdout.write(rr.toTinydns())
+    }
+    catch (e) {
+      console.error(rr)
+      throw e
+    }
   }
 }
 

--- a/bin/dns-zone.js
+++ b/bin/dns-zone.js
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!node
 
 import fs   from 'fs/promises'
 import path from 'path'

--- a/bin/dns-zone.js
+++ b/bin/dns-zone.js
@@ -247,10 +247,11 @@ function ingestZoneData () {
 
     if (opts.verbose) console.error(`reading file ${filePath}`)
 
-    fs.readFile(filePath).then(buf => {
+    fs.readFile(filePath).then(async buf => {
+      const str = await bind.includeIncludes(buf.toString(), opts)
       resolve({
         type: opts.import,
-        data: buf.toString(),
+        data: str,
       })
     }).catch(reject)
   })

--- a/bin/dns-zone.js
+++ b/bin/dns-zone.js
@@ -20,7 +20,7 @@ const rr = new RR.A(null)
 // CLI argument processing
 const opts = cmdLineArgs(usageOptions())._all
 if (opts.verbose) console.error(opts)
-if (opts.help) usage()
+if (opts.help) usage(0)
 
 const optsObj = {
   origin: rr.fullyQualify(opts.origin) || '',
@@ -72,9 +72,14 @@ function checkZone (zoneArray) {
   })
 }
 
-function usage () {
-  console.error(cmdLineUsage(usageSections()))
-  process.exit(1)
+function usage (code) {
+  if (code === 0) {
+    console.log(cmdLineUsage(usageSections()))
+  }
+  else {
+    console.error(cmdLineUsage(usageSections()))
+  }
+  process.exit(code)
 }
 
 function usageOptions () {
@@ -226,8 +231,8 @@ function usageSections () {
 function ingestZoneData () {
   return new Promise((resolve, reject) => {
 
-    if (!opts.import) usage()
-    if (!opts.file) usage()
+    if (!opts.import) usage(1)
+    if (!opts.file) usage(1)
 
     let filePath = opts.file
 

--- a/bin/dns-zone.js
+++ b/bin/dns-zone.js
@@ -66,7 +66,7 @@ function checkZone (zoneArray) {
       resolve(zoneArray)
     }
     catch (e) {
-      // console.error(e)
+      console.error(e)
       reject(e)
     }
   })

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,1 +1,0 @@
-!.gitignore

--- a/index.js
+++ b/index.js
@@ -80,3 +80,18 @@ export async function serialByFileStat (filePath) {
   const stat = await fs.stat(filePath)
   return Math.round(stat.mtime.getTime() / 1000)
 }
+
+export function toSeconds (str) {
+  if (/^[0-9]+$/.test(str)) return parseInt(str, 10) // all numeric
+
+  const re = /(?:([0-9]+)w)?(?:([0-9]+)d)?(?:([0-9]+)h)?(?:([0-9]+)m)?(?:([0-9]+)s)?/i
+  const match = str.match(re)
+  if (!match) throw new Error(`unable to convert ${str} to seconds`)
+
+  const [ weeks, days, hours, minutes, seconds ] = match.slice(1)
+  return  parseInt(weeks   || 0) * 604800
+        + parseInt(days    || 0) *  86400
+        + parseInt(hours   || 0) *   3600
+        + parseInt(minutes || 0) *     60
+        + parseInt(seconds || 0) *      1
+}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 
 import fs from 'fs/promises'
 
-import bind from './lib/bind.js'
+import bind    from './lib/bind.js'
 import maradns from './lib/maradns.js'
 import tinydns from './lib/tinydns.js'
 

--- a/lib/bind.js
+++ b/lib/bind.js
@@ -50,7 +50,7 @@ export async function parseZoneFile (str, implicitOrigin) {
     const [ owner, ttl, c, type, rdata ] = match.slice(1)
     const iterRR = {
       owner: owner ? owner.trim() : owner,
-      ttl  : parseInt(ttl ? ttl.trim() : ttl) || zoneOpts.ttl,
+      ttl  : expandTTL(ttl),
       class: (c ? c.trim().toUpperCase() : c) || 'IN',
       type : type.trim().toUpperCase(),
       rdata: rdata.trim(),
@@ -115,6 +115,11 @@ function expandRdataShortcuts (iterRR) {
       iterRR.rdata = rr.fullyQualify(iterRR.rdata, zoneOpts.origin)
       break
   }
+}
+
+function expandTTL (str) {
+  if (!str) return zoneOpts.ttl
+  return dz.toSeconds(str.trim())
 }
 
 function isBlank (str, res) {

--- a/lib/bind.js
+++ b/lib/bind.js
@@ -1,5 +1,7 @@
 
-import os from 'os'
+import fs   from 'fs/promises'
+import os   from 'os'
+import path from 'path'
 
 import * as RR from 'dns-resource-record'
 
@@ -12,13 +14,15 @@ export const zoneOpts = {}
 export default { zoneOpts, parseZoneFile }
 
 const re = {
-  directive : /^\$([A-Za-z]+)\s+([^\s]+)\s*$/,
-  zoneTTL   : /^\$TTL\s+([0-9]{1,5})\s*(;.*)?$/,
-  zoneOrigin: /^\$ORIGIN\s+([^\s]+?)\s*(;.*)?$/,
-  zoneRR    : /^([^\s]+)?\s*([0-9]{1,5})?\s*(IN|CS|CH|HS|NONE|ANY)?\s+(A|AAAA|APL|CAA|CERT|CNAME|DHCID|DNAME|DNSKEY|DS|HINFO|HIP|IPSECKEY|KEY|KX|LOC|MD|MF|MX|NAPTR|NS|NSEC|NSEC3|NSEC3PARAM|NXT|OPENPGPKEY|PTR|RP|RRSIG|SIG|SMIMEA|SOA|SPF|SRV|SSHFP|SVCB|TLSA|TXT|URI|TYPE)\s+(.*?)\s*$/,
-  blank     : /^\s*?$/,
-  comment   : /^\s*(?:\/\/|;)[^\r\n]*?$/,
+  directive: /^\$([A-Za-z]+)\s+([^\s]+)\s*(?:([^\s]+)\s+)?(;.*)?$/,
+  ttl        : /([0-9]{1,5})/,
+  classes    : /(IN|CS|CH|HS|NONE|ANY)/,
+  rrtypes    : /(A|AAAA|APL|CAA|CERT|CNAME|DHCID|DNAME|DNSKEY|DS|HINFO|HIP|IPSECKEY|KEY|KX|LOC|MD|MF|MX|NAPTR|NS|NSEC|NSEC3|NSEC3PARAM|NXT|OPENPGPKEY|PTR|RP|RRSIG|SIG|SMIMEA|SOA|SPF|SRV|SSHFP|SVCB|TLSA|TXT|URI|TYPE)/,
+  zoneRR     : /^([^\s]+)?\s*([0-9]{1,5})?\s*(IN|CS|CH|HS|NONE|ANY)?\s+(A|AAAA|APL|CAA|CERT|CNAME|DHCID|DNAME|DNSKEY|DS|HINFO|HIP|IPSECKEY|KEY|KX|LOC|MD|MF|MX|NAPTR|NS|NSEC|NSEC3|NSEC3PARAM|NXT|OPENPGPKEY|PTR|RP|RRSIG|SIG|SMIMEA|SOA|SPF|SRV|SSHFP|SVCB|TLSA|TXT|URI|TYPE)\s+(.*?)\s*$/,
+  blank      : /^\s*?$/,
+  comment    : /^\s*(?:\/\/|;)[^\r\n]*?$/,
 }
+// re.zoneRR = new RegExp(`^([^\\s]+)?\\s*${re.ttl}?${re.classes}?\\s+${re.rrtypes}?\\s+(.*?)\\s*$`)
 
 export async function parseZoneFile (str, implicitOrigin) {
 
@@ -33,15 +37,13 @@ export async function parseZoneFile (str, implicitOrigin) {
 
     if (isBlank(line, res)) continue
     if (isComment(line, res)) continue
+    if (isDirective(line, res)) continue
 
     line = dz.stripComment(line, '"', ';')
 
     if (Object.keys(rrWIP).length) {  // a continuation started
       resumeContinuation(line, rrWIP, res); continue
     }
-
-    if (isZoneTTL(line, res)) continue
-    if (isZoneOrigin(line, res)) continue
 
     const match = line.match(re.zoneRR)
     if (!match) throw new Error(`parse failure during line:\n\t${line}`)
@@ -132,24 +134,25 @@ function isComment (str, res) {
   return false
 }
 
-function isZoneTTL (str, res) {
-  const match = str.match(re.zoneTTL)
+function isDirective (line, res) {
+
+  const match = line.match(re.directive)
   if (!match) return false
 
-  zoneOpts.ttl = dz.valueCleanup(match[1])
-  res.push({ $TTL: zoneOpts.ttl })
+  switch (match[1]) {
+    case 'TTL':
+      zoneOpts.ttl = dz.valueCleanup(match[2])
+      res.push({ $TTL: zoneOpts.ttl })
+      return true
+    case 'ORIGIN':
+      zoneOpts.origin = rr.fullyQualify(dz.valueCleanup(match[2]))
+      res.push({ $ORIGIN: zoneOpts.origin })
+      return true
+    case 'INCLUDE':
+      return true
+  }
 
-  return true
-}
-
-function isZoneOrigin (str, res) {
-  const match = str.match(re.zoneOrigin)
-  if (!match) return false
-
-  zoneOpts.origin = rr.fullyQualify(dz.valueCleanup(match[1]))
-  res.push({ $ORIGIN: zoneOpts.origin })
-
-  return true
+  return false
 }
 
 function parseRR (rr) {
@@ -205,4 +208,29 @@ export async function expandShortcuts (zoneArray) {
     }
     if (!origin) throw new Error(`zone origin ambiguous, cowardly bailing out`)
   }
+}
+
+export async function includeIncludes (str, opts) {
+
+  const parts = str.split(/^\$INCLUDE\s+([^\s]+)\s*([^\s]+\s*)?(?:;.*)?$/gm)
+  if (parts.length === 1) return str
+
+  const result = []
+  const includeDir = path.dirname(opts.file)
+
+  while (parts.length) {
+    const next = parts.shift()  // line(s) preceding $INCLUDE
+    result.push(next.trim())
+    if (parts.length === 0) break  // recursion break
+
+    const includeFile = path.resolve(includeDir, parts.shift())
+    const origin = parts.shift()
+    if (origin) result.push(`$ORIGIN: ${origin}\n`)
+    const contents = await fs.readFile(includeFile)
+    result.push(contents.toString())
+
+    if (parts.length === 0) break
+  }
+
+  return result.join(os.EOL)
 }

--- a/lib/bind.js
+++ b/lib/bind.js
@@ -12,6 +12,7 @@ export const zoneOpts = {}
 export default { zoneOpts, parseZoneFile }
 
 const re = {
+  directive : /^\$([A-Za-z]+)\s+([^\s]+)\s*$/,
   zoneTTL   : /^\$TTL\s+([0-9]{1,5})\s*(;.*)?$/,
   zoneOrigin: /^\$ORIGIN\s+([^\s]+?)\s*(;.*)?$/,
   zoneRR    : /^([^\s]+)?\s*([0-9]{1,5})?\s*(IN|CS|CH|HS|NONE|ANY)?\s+(A|AAAA|APL|CAA|CERT|CNAME|DHCID|DNAME|DNSKEY|DS|HINFO|HIP|IPSECKEY|KEY|KX|LOC|MD|MF|MX|NAPTR|NS|NSEC|NSEC3|NSEC3PARAM|NXT|OPENPGPKEY|PTR|RP|RRSIG|SIG|SMIMEA|SOA|SPF|SRV|SSHFP|SVCB|TLSA|TXT|URI|TYPE)\s+(.*?)\s*$/,
@@ -23,8 +24,12 @@ export async function parseZoneFile (str, implicitOrigin) {
 
   const res = []
   const rrWIP = {}
+  let lineCount = 0
 
   for (let line of str.split(os.EOL)) {
+
+    lineCount++
+    if (lineCount % 500 === 0) process.stdout.write('.')
 
     if (isBlank(line, res)) continue
     if (isComment(line, res)) continue
@@ -39,7 +44,7 @@ export async function parseZoneFile (str, implicitOrigin) {
     if (isZoneOrigin(line, res)) continue
 
     const match = line.match(re.zoneRR)
-    if (!match) throw new Error(`parse failure, unrecognized: ${line}`)
+    if (!match) throw new Error(`parse failure during line:\n\t${line}`)
 
     const [ owner, ttl, c, type, rdata ] = match.slice(1)
     const iterRR = {
@@ -157,7 +162,7 @@ function parseRR (rr) {
   }
   catch (e) {
     console.error(rr)
-    console.error(e.message)
+    // console.error(e.message)
     throw e
   }
 }

--- a/lib/bind.js
+++ b/lib/bind.js
@@ -15,14 +15,13 @@ export default { zoneOpts, parseZoneFile }
 
 const re = {
   directive: /^\$([A-Za-z]+)\s+([^\s]+)\s*(?:([^\s]+)\s+)?(;.*)?$/,
-  ttl        : /([0-9]{1,5})/,
-  classes    : /(IN|CS|CH|HS|NONE|ANY)/,
-  rrtypes    : /(A|AAAA|APL|CAA|CERT|CNAME|DHCID|DNAME|DNSKEY|DS|HINFO|HIP|IPSECKEY|KEY|KX|LOC|MD|MF|MX|NAPTR|NS|NSEC|NSEC3|NSEC3PARAM|NXT|OPENPGPKEY|PTR|RP|RRSIG|SIG|SMIMEA|SOA|SPF|SRV|SSHFP|SVCB|TLSA|TXT|URI|TYPE)/,
-  zoneRR     : /^([^\s]+)?\s*([0-9]{1,5})?\s*(IN|CS|CH|HS|NONE|ANY)?\s+(A|AAAA|APL|CAA|CERT|CNAME|DHCID|DNAME|DNSKEY|DS|HINFO|HIP|IPSECKEY|KEY|KX|LOC|MD|MF|MX|NAPTR|NS|NSEC|NSEC3|NSEC3PARAM|NXT|OPENPGPKEY|PTR|RP|RRSIG|SIG|SMIMEA|SOA|SPF|SRV|SSHFP|SVCB|TLSA|TXT|URI|TYPE)\s+(.*?)\s*$/,
+  ttl        : '([0-9]{1,5})',
+  classes    : '(IN|CS|CH|HS|NONE|ANY)',
+  rrtypes    : '(A|AAAA|APL|CAA|CERT|CNAME|DHCID|DNAME|DNSKEY|DS|HINFO|HIP|IPSECKEY|KEY|KX|LOC|MD|MF|MX|NAPTR|NS|NSEC|NSEC3|NSEC3PARAM|NXT|OPENPGPKEY|PTR|RP|RRSIG|SIG|SMIMEA|SOA|SPF|SRV|SSHFP|SVCB|TLSA|TXT|URI|TYPE)',
   blank      : /^\s*?$/,
   comment    : /^\s*(?:\/\/|;)[^\r\n]*?$/,
 }
-// re.zoneRR = new RegExp(`^([^\\s]+)?\\s*${re.ttl}?${re.classes}?\\s+${re.rrtypes}?\\s+(.*?)\\s*$`)
+re.zoneRR = new RegExp(`^([^\\s]+)?\\s*${re.ttl}?\\s*${re.classes}?\\s+${re.rrtypes}\\s+(.*?)\\s*$`)
 
 export async function parseZoneFile (str, implicitOrigin) {
 

--- a/lib/maradns.js
+++ b/lib/maradns.js
@@ -67,6 +67,7 @@ export async function parseZoneFile (str) {
       rdata: rdata.trim(),
     }
 
+    if (iterRR.owner === '') iterRR.owner = zoneOpts.origin
     iterRR.owner = dz.replaceChar(iterRR.owner, "'", '%', zoneOpts.origin)
     iterRR.rdata = dz.removeChar(iterRR.rdata, "'", '~').trim()
 
@@ -100,7 +101,9 @@ export async function parseZoneFile (str) {
         break
       case 'SOA':
         iterRR.rdata = dz.replaceChar(iterRR.rdata, "'", '@', '.')
-        iterRR.rdata = iterRR.rdata.replace(/\/serial/, zoneOpts.serial)
+        if (zoneOpts.serial) {
+          iterRR.rdata = iterRR.rdata.replace(/\/serial/, zoneOpts.serial)
+        }
         break
       case 'SPF':
       case 'TXT':
@@ -139,10 +142,15 @@ export async function parseZoneFile (str) {
     }
 
     // console.log(iterRR)
-
-    res.push(
-      new RR[iterRR.type]({ bindline: `${iterRR.owner} ${iterRR.ttl} ${iterRR.class} ${iterRR.type} ${iterRR.rdata}` })
-    )
+    const asBind = `${iterRR.owner} ${iterRR.ttl} ${iterRR.class} ${iterRR.type} ${iterRR.rdata}`
+    try {
+      res.push(new RR[iterRR.type]({ bindline: asBind }))
+    }
+    catch (e) {
+      console.error(asBind)
+      // console.error(e)
+      throw e
+    }
   }
 
   return res

--- a/lib/tinydns.js
+++ b/lib/tinydns.js
@@ -1,65 +1,77 @@
 
 import * as RR from 'dns-resource-record'
 
+import * as zone from '../index.js'
+
 const rr = new RR.A(null)
 
-export default { parseData }
+export const zoneOpts = {}
+
+export default { zoneOpts, parseData }
 
 export async function parseData (str) {
   // https://cr.yp.to/djbdns/tinydns-data.html
   const rrs = []
+  let curLine
 
-  for (const line of str.split('\n')) {
-    if (line === '') continue // "Blank lines are ignored"
-    if (/^#/.test(line)) continue // "Comment line. The line is ignored."
-    switch (line[0]) {  // first char of line
-      case '%':  // location
-        break
-      case '-':  // ignored
-        break
-      case '.':  // NS, A, SOA
-        rrs.push(...parseTinyDot(line))
-        break
-      case '&':  // NS, A
-        rrs.push(...parseTinyAmpersand(line))
-        break
-      case '=':  // A, PTR
-        rrs.push(...parseTinyEquals(line))
-        break
-      case '+':  // A
-        rrs.push(new RR.A({ tinyline: line }))
-        break
-      case '@':  // MX, A
-        rrs.push(...parseTinyAt(line))
-        break
-      case '\'': // TXT
-        rrs.push(new RR.TXT({ tinyline: line }))
-        break
-      case '^':  // PTR
-        rrs.push(new RR.PTR({ tinyline: line }))
-        break
-      case 'C':  // CNAME
-        rrs.push(new RR.CNAME({ tinyline: line }))
-        break
-      case 'Z':  // SOA
-        rrs.push(new RR.SOA({ tinyline: line }))
-        break
-      case ':':  // generic
-        rrs.push(parseTinyGeneric(line))
-        break
-      case '3':
-        rrs.push(new RR.AAAA({ tinyline: line }))
-        break
-      case '6':
-        rrs.push(...parseTinySix(line))
-        break
-      case 'S':  // SRV
-        rrs.push(new RR.SRV({ tinyline: line }))
-        break
-      default:
-        throw new Error(`garbage found in tinydns data: ${line}`)
-    }
+  try {
+    for (const line of str.split('\n')) {
+      curLine = line
+      if (line === '') continue // "Blank lines are ignored"
+      if (/^#/.test(line)) continue // "Comment line. The line is ignored."
+      switch (line[0]) {  // first char of line
+        case '%':  // location
+          break
+        case '-':  // ignored
+          break
+        case '.':  // NS, A, SOA
+          rrs.push(...parseTinyDot(line))
+          break
+        case '&':  // NS, A
+          rrs.push(...parseTinyAmpersand(line))
+          break
+        case '=':  // A, PTR
+          rrs.push(...parseTinyEquals(line))
+          break
+        case '+':  // A
+          rrs.push(new RR.A({ tinyline: line }))
+          break
+        case '@':  // MX, A
+          rrs.push(...parseTinyAt(line))
+          break
+        case '\'': // TXT
+          rrs.push(new RR.TXT({ tinyline: line }))
+          break
+        case '^':  // PTR
+          rrs.push(new RR.PTR({ tinyline: line }))
+          break
+        case 'C':  // CNAME
+          rrs.push(new RR.CNAME({ tinyline: line }))
+          break
+        case 'Z':  // SOA
+          rrs.push(new RR.SOA({ default: zoneOpts, tinyline: line }))
+          break
+        case ':':  // generic
+          rrs.push(parseTinyGeneric(line))
+          break
+        case '3':
+          rrs.push(new RR.AAAA({ tinyline: line }))
+          break
+        case '6':
+          rrs.push(...parseTinySix(line))
+          break
+        case 'S':  // SRV
+          rrs.push(new RR.SRV({ tinyline: line }))
+          break
+        default:
+          throw new Error(`garbage found in tinydns data: ${line}`)
+      }
     // console.log(line)
+    }
+  }
+  catch (e) {
+    console.error(curLine)
+    throw e
   }
 
   return rrs
@@ -101,7 +113,7 @@ function parseTinyDot (str) {
     type     : 'SOA',
     mname    : rr.fullyQualify(/\./.test(mname) ? mname : `${mname}.ns.${fqdn}`),
     rname    : rr.fullyQualify(`hostmaster.{fqdn}`),
-    serial   : 1647927758,  // TODO, format is epoch seconds
+    serial   : zoneOpts.serial || zone.serialByDate(),
     refresh  : 16384,
     retry    : 2048,
     expire   : 1048576,
@@ -201,34 +213,21 @@ function parseTinyGeneric (str) {
   const [ , n, , , , ] = str.substring(1).split(':')
 
   switch (parseInt(n, 10)) {
-    case 13:
-      return new RR.HINFO({ tinyline: str })
-    case 28:
-      return new RR.AAAA({ tinyline: str })
-    case 29:
-      return new RR.LOC({ tinyline: str })
-    case 33:
-      return new RR.SRV({ tinyline: str })
-    case 35:
-      return new RR.NAPTR({ tinyline: str })
-    case 39:
-      return new RR.DNAME({ tinyline: str })
-    case 43:
-      return new RR.DS({ tinyline: str })
-    case 44:
-      return new RR.SSHFP({ tinyline: str })
-    case 48:
-      return new RR.DNSKEY({ tinyline: str })
-    case 52:
-      return new RR.TLSA({ tinyline: str })
-    case 53:
-      return new RR.SMIMEA({ tinyline: str })
-    case 99:
-      return new RR.SPF({ tinyline: str })
-    case 256:
-      return new RR.URI({ tinyline: str })
-    case 257:
-      return new RR.CAA({ tinyline: str })
+    case 13 : return new RR.HINFO ({ tinyline: str })
+    case 28 : return new RR.AAAA  ({ tinyline: str })
+    case 29 : return new RR.LOC   ({ tinyline: str })
+    case 33 : return new RR.SRV   ({ tinyline: str })
+    case 35 : return new RR.NAPTR ({ tinyline: str })
+    case 39 : return new RR.DNAME ({ tinyline: str })
+    case 43 : return new RR.DS    ({ tinyline: str })
+    case 44 : return new RR.SSHFP ({ tinyline: str })
+    case 45 : return new RR.IPSECKEY({ tinyline: str })
+    case 48 : return new RR.DNSKEY({ tinyline: str })
+    case 52 : return new RR.TLSA  ({ tinyline: str })
+    case 53 : return new RR.SMIMEA({ tinyline: str })
+    case 99 : return new RR.SPF   ({ tinyline: str })
+    case 256: return new RR.URI   ({ tinyline: str })
+    case 257: return new RR.CAA   ({ tinyline: str })
     default:
       console.log(str)
       throw new Error(`unsupported tinydns generic record (${n})`)

--- a/lib/tinydns.js
+++ b/lib/tinydns.js
@@ -87,6 +87,21 @@ function parseTinyDot (str) {
   const [ fqdn, ip, mname, ttl, ts, loc ] = str.substring(1).split(':')
   const rrs = []
 
+  rrs.push(new RR.SOA({
+    owner    : rr.fullyQualify(fqdn),
+    ttl      : parseInt(ttl, 10),
+    type     : 'SOA',
+    mname    : rr.fullyQualify(/\./.test(mname) ? mname : `${mname}.ns.${fqdn}`),
+    rname    : rr.fullyQualify(`hostmaster.{fqdn}`),
+    serial   : zoneOpts.serial || zone.serialByDate(),
+    refresh  : 16384,
+    retry    : 2048,
+    expire   : 1048576,
+    minimum  : 2560,
+    timestamp: parseInt(ts) || '',
+    location : loc !== '' && loc !== '\n' ? loc : '',
+  }))
+
   rrs.push(new RR.NS({
     owner    : rr.fullyQualify(fqdn),
     ttl      : parseInt(ttl, 10),
@@ -106,21 +121,6 @@ function parseTinyDot (str) {
       location : loc !== '' && loc !== '\n' ? loc : '',
     }))
   }
-
-  rrs.push(new RR.SOA({
-    owner    : rr.fullyQualify(fqdn),
-    ttl      : parseInt(ttl, 10),
-    type     : 'SOA',
-    mname    : rr.fullyQualify(/\./.test(mname) ? mname : `${mname}.ns.${fqdn}`),
-    rname    : rr.fullyQualify(`hostmaster.{fqdn}`),
-    serial   : zoneOpts.serial || zone.serialByDate(),
-    refresh  : 16384,
-    retry    : 2048,
-    expire   : 1048576,
-    minimum  : 2560,
-    timestamp: parseInt(ts) || '',
-    location : loc !== '' && loc !== '\n' ? loc : '',
-  }))
   return rrs
 }
 

--- a/lib/zone.js
+++ b/lib/zone.js
@@ -6,12 +6,18 @@ export default class ZONE extends Map {
     this.RR = []
     this.SOA = {}
 
-    this.setOrigin(opts.origin)
+    if (opts.origin) this.setOrigin(opts.origin)
     this.setTTL(opts.ttl)
 
     if (opts.RR) {
       for (const r of opts.RR) {
-        this.addRR(r)
+        try {
+          this.addRR(r)
+        }
+        catch (e) {
+          console.error(r)
+          console.error(e)
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dns-zone-validator",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "DNS Zone",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
   "dependencies": {
     "command-line-args": "^5.2.1",
     "command-line-usage": "^6.1.1",
-    "dns-resource-record": "^1.0.0"
+    "dns-resource-record": "^1.1.1"
   }
 }

--- a/test/bind.js
+++ b/test/bind.js
@@ -4,7 +4,7 @@ import fs     from 'fs/promises'
 import os     from 'os'
 
 import * as RR from 'dns-resource-record'
-import bind from '../lib/bind.js'
+import * as bind from '../lib/bind.js'
 
 beforeEach(() => {
   Object.keys(bind.zoneOpts).map(k => delete bind.zoneOpts[k])
@@ -445,6 +445,15 @@ describe('bind', function () {
       const rrs = await bind.parseZoneFile(buf.toString())
       // console.dir(rrs, { depth: null })
       assert.equal(rrs.length, 17)
+    })
+
+    it('parses example.net zone file (with $INCLUDE)', async () => {
+      const file = './test/fixtures/bind/example.net'
+      const buf = await fs.readFile(file)
+      const str = await bind.includeIncludes(buf.toString(), { file: file })
+      const rrs = await bind.parseZoneFile(str)
+      // console.dir(rrs, { depth: null })
+      assert.equal(rrs.length, 7)
     })
   })
 })

--- a/test/bind.js
+++ b/test/bind.js
@@ -1,6 +1,7 @@
 
 import assert from 'assert'
 import fs     from 'fs/promises'
+import os     from 'os'
 
 import * as RR from 'dns-resource-record'
 import bind from '../lib/bind.js'
@@ -22,7 +23,7 @@ describe('bind', function () {
 
     it('parses two blank lines', async () => {
       bind.zoneOpts.showBlank = true
-      const r = await bind.parseZoneFile(`\n`)
+      const r = await bind.parseZoneFile(os.EOL)
       // console.dir(r, { depth: null })
       assert.deepStrictEqual(r, [ '', '' ])
     })
@@ -67,7 +68,7 @@ describe('bind', function () {
                       2048     ; retry
                       604800    ; expiry
                       2560   ; minimum
-                      )\n`)
+                      )${os.EOL}`)
 
       // console.dir(r, { depth: null })
       assert.deepStrictEqual(r[0], new RR.SOA({

--- a/test/dns-zone.js
+++ b/test/dns-zone.js
@@ -22,7 +22,7 @@ describe('nt-zone.js', function () {
     }
   })
 
-  it('parses example zone file', async function () {
+  it('parses BIND example zone file', async function () {
     const binPath = path.resolve('bin', 'dns-zone.js')
     const args = [ '-i', 'bind', '-f', './test/fixtures/bind/example.com', '-o', 'cadillac.net' ]
     // console.log(`${binPath} ${args.join(' ')}`)
@@ -47,6 +47,63 @@ mail2.example.com.    3600  A
 mail3.example.com.    3600  A      
 `)
       assert.strictEqual(stderr, ``)
+    }
+    catch (e) {
+      assert.ifError(e)
+    }
+  })
+
+  it('parses tinydns example data file to maradns', async function () {
+    const binPath = path.resolve('bin', 'dns-zone.js')
+    const args = [ '-i', 'tinydns', '-f', './test/fixtures/tinydns/data', '-e', 'maradns' ]
+    // console.log(`${binPath} ${args.join(' ')}`)
+    try {
+      const { stdout, stderr } = await execFile(binPath, args)
+      assert.strictEqual(stdout, `theartfarm.com.\t SOA\tns3.theartfarm.com.\thostmaster.theartfarm.com.\t2022032700\t16384\t2048\t1048576\t2560 ~
+theartfarm.com.\t+14400\tNS\tns3.theartfarm.com. ~
+theartfarm.com.\t+14400\tNS\tns1.theartfarm.com. ~
+theartfarm.com.\t+14400\tNS\tns2.theartfarm.com. ~
+theartfarm.com.\t+28800\tMX\t10\tmail.theartfarm.com. ~
+theartfarm.com.\t+86400\tTXT\t'v=spf1 include:mx.theartfarm.com ip4:69.64.153.131 ip4:172.16.16.5 -all' ~
+theartfarm.com.\t+28800\tA\t66.128.51.172 ~
+www.theartfarm.com.\t+28800\tMX\t10\tmail.theartfarm.com. ~
+dmarc.theartfarm.com.\t+86400\tMX\t10\tmail.theartfarm.com. ~
+theartfarm.com.\t+86400\tTXT\t'stripe-verification=a5fd4f2f0595baed5ff34b5faa4fbbfe1a3c558edb5d3e1f79a1b47c17034045' ~
+localhost.theartfarm.com.\t+86400\tA\t127.0.0.1 ~
+ns1.theartfarm.com.\t+86400\tA\t192.48.85.147 ~
+www.theartfarm.com.\t+28800\tA\t66.128.51.172 ~
+art.theartfarm.com.\t+86400\tCNAME\tmail.theartfarm.com. ~
+ftp.theartfarm.com.\t+28800\tCNAME\twww.theartfarm.com. ~
+pop.theartfarm.com.\t+28800\tCNAME\tmail.theartfarm.com. ~
+smtp.theartfarm.com.\t+28800\tCNAME\tmail.theartfarm.com. ~
+imap.theartfarm.com.\t+28800\tCNAME\tmail.theartfarm.com. ~
+dns.theartfarm.com.\t+86400\tCNAME\tdns.tnpi.net. ~
+www2.theartfarm.com.\t+3600\tCNAME\tns2.theartfarm.com. ~
+ns2.theartfarm.com.\t+28800\tA\t66.128.51.172 ~
+mail.theartfarm.com.\t+28800\tTXT\t'v=spf1 a -all' ~
+www.theartfarm.com.\t+86400\tTXT\t'v=spf1 a mx ip4:127.0.0.24 -all' ~
+vhost0.theartfarm.com.\t+86400\tA\t66.128.51.173 ~
+mail.theartfarm.com.\t+28800\tA\t66.128.51.165 ~
+toaster.theartfarm.com.\t+3600\tCNAME\tmail.theartfarm.com. ~
+ns3.theartfarm.com.\t+28800\tA\t138.210.133.60 ~
+lo.mail.theartfarm.com.\t+86400\tA\t127.0.0.6 ~
+mar2013._domainkey.theartfarm.com.\t+3600\tTXT\t'v=DKIM1;p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5Q41fZ8CqpSgzSWpDY88oGq+bXKHdROGHmyjY6+b8qLUmdoHgpcaBUhL2zhZChvx5uayVJRV/gWxPZtODsozOqPk6fl8Mn1VH1MBsuQdShnC0a/Tcm8bPW0NE2viHysUamvL+X5Ea9H2GyVGKpe6rdKrmUiCzZyRYwTYqLvC9HhkTNWjR3TuP5mA2rmBO8IBPBFkdaz7W' 'veNaiR8ImegA+wv1uCYcQLwcz3bn/U2yK2UzFGsJLZ1KCTqr8WMPTuy1zc5zClHpZZMmCl3uk02bE59RVa7zzyZwVEGeRcjouq0rh5JCl057rMK2cwA2wu//8svN+pGZAKJCnuFlpC0bwIDAQAB' ~
+_dmarc.theartfarm.com.\t+86400\tTXT\t'v=DMARC1; p=reject; rua=mailto:dmarc-feedback@theartfarm.com; ruf=mailto:dmarc-feedback@theartfarm.com; pct=100' ~
+_dmarc.dmarc.theartfarm.com.\t+86400\tTXT\t'v=DMARC1; p=reject; pct=100' ~
+dmarc.theartfarm.com.\t+86400\tTXT\t'v=spf1 include:mx.theartfarm.com -all' ~
+dmarc.theartfarm.com.\t+86400\tA\t66.128.51.165 ~
+mx.theartfarm.com.\t+86400\tTXT\t'v=spf1 ip4:66.128.51.160/27 ip4:192.48.85.146/29 ip4:173.45.131.0/27 ip4:204.11.99.0/27 ip6:2605:7900:20:a::/64 ip6:2605:ae00:329::0/64 -all' ~
+htpta.theartfarm.com.\t+86400\tCNAME\tvhost0.theartfarm.com. ~
+vhost0.theartfarm.com.\t+86400\tTXT\t'v=spf1 include:mx.theartfarm.com -all' ~
+ns3.theartfarm.com.\t+86400\tTXT\t'v=spf1 a ip4:138.210.133.60 ip4:46.105.8.147 -all' ~
+wordpress.theartfarm.com.\t+86400\tCNAME\twww.theartfarm.com. ~
+apr2019._domainkey.mail.theartfarm.com.\t+86400\tTXT\t'v=DKIM1;p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoW91trHF9nBzY3DeFtauDbPbr904YNBgW7mh/8s5Fcmsi3TPB1bSqyBcr2BjYGqCG1KPFBvs+IRZNMDgHJ4wMSdC+4Pt6wXkMJpElNg4DjuP7q2UALJsOQ/H54VtH8TWVMOekmc4W3um8ZqxePGJkWd2UGV+YT00dR8jLne5d+9MXo3CayOe3L7rK9uEvm0u8dLYLJaTm' 'PdKI+8LWEIuxC4KeRsaB/10M7NIaR73C5wB0HlTOm7MQW3806rTdlFYpO9Rtx2uV3stqCIfUYK9qeGLJFXHjLxh0nki4ztVIZdPi9TkZnj+juS5k8GTADSGy7PWawUnbhjEDyd4JX5YxwIDAQAB' ~
+ns1.theartfarm.com.\t+86400\tA\t173.45.131.5 ~
+ns1.theartfarm.com.\t+86400\tA\t204.11.99.5 ~
+mx-out.theartfarm.com.\t+86400\tA\t66.128.51.178 ~
+bounce.theartfarm.com.\t+86400\tCNAME\tcustom-email-domain.stripe.com. ~
+`)
+      assert.strictEqual(stderr, '')
     }
     catch (e) {
       assert.ifError(e)

--- a/test/dns-zone.js
+++ b/test/dns-zone.js
@@ -1,0 +1,55 @@
+
+import assert from 'assert'
+import * as child from 'child_process'
+import path   from 'path'
+import util   from 'util'
+
+const execFile = util.promisify(child.execFile)
+
+describe('nt-zone.js', function () {
+  it('prints help message', async function () {
+    const binPath = path.resolve('bin', 'dns-zone.js')
+    const args = [ '-h' ]
+    try {
+      const { stdout, stderr } = await execFile(binPath, args)
+      // console.log(stdout)
+      // console.log(stderr)
+      assert.ok(/|Z|O|N|E|/.test(stdout))
+      assert.strictEqual(stderr, '')
+    }
+    catch (e) {
+      assert.ifError(e)
+    }
+  })
+
+  it('parses example zone file', async function () {
+    const binPath = path.resolve('bin', 'dns-zone.js')
+    const args = [ '-i', 'bind', '-f', './test/fixtures/bind/example.com', '-o', 'cadillac.net' ]
+    // console.log(`${binPath} ${args.join(' ')}`)
+    try {
+      const { stdout, stderr } = await execFile(binPath, args)
+      assert.strictEqual(stdout, `$ORIGIN example.com.
+$TTL 3600
+example.com.          3600  SOA    
+example.com.          3600  NS     
+example.com.          3600  NS     
+example.com.          3600  MX     
+example.com.          3600  MX     
+example.com.          3600  MX     
+example.com.          3600  A      
+example.com.          3600  AAAA   
+ns.example.com.       3600  A      
+ns.example.com.       3600  AAAA   
+www.example.com.      3600  CNAME  
+wwwtest.example.com.  3600  CNAME  
+mail.example.com.     3600  A      
+mail2.example.com.    3600  A      
+mail3.example.com.    3600  A      
+`)
+      assert.strictEqual(stderr, ``)
+    }
+    catch (e) {
+      assert.ifError(e)
+    }
+  })
+})

--- a/test/dns-zone.js
+++ b/test/dns-zone.js
@@ -116,7 +116,7 @@ bounce.theartfarm.com.\t+86400\tCNAME\tcustom-email-domain.stripe.com. ~
     // console.log(`${binPath} ${args.join(' ')}`)
     try {
       const { stdout, stderr } = await execFile(binPath, args)
-      assert.strictEqual(stdout, `Zx.org:x.org:john\\.doe.x.org:1651193101:7200:3600:604800:1800:86400::
+      assert.strictEqual(stdout, `Zx.org:x.org:john\\.doe.x.org:2:7200:3600:604800:1800:86400::
 &example.net::a.example.net:86400::
 &example.net::b.example.net:86400::
 &example.net::ns1.example.net:86400::

--- a/test/dns-zone.js
+++ b/test/dns-zone.js
@@ -9,9 +9,9 @@ const execFile = util.promisify(child.execFile)
 describe('nt-zone.js', function () {
   it('prints help message', async function () {
     const binPath = path.resolve('bin', 'dns-zone.js')
-    const args = [ '-h' ]
+    const args = [ binPath, '-h' ]
     try {
-      const { stdout, stderr } = await execFile(binPath, args)
+      const { stdout, stderr } = await execFile('node', args)
       // console.log(stdout)
       // console.log(stderr)
       assert.ok(/|Z|O|N|E|/.test(stdout))
@@ -24,10 +24,10 @@ describe('nt-zone.js', function () {
 
   it('parses BIND example zone file', async function () {
     const binPath = path.resolve('bin', 'dns-zone.js')
-    const args = [ '-i', 'bind', '-f', './test/fixtures/bind/example.com', '-o', 'cadillac.net' ]
+    const args = [ binPath, '-i', 'bind', '-f', './test/fixtures/bind/example.com', '-o', 'cadillac.net' ]
     // console.log(`${binPath} ${args.join(' ')}`)
     try {
-      const { stdout, stderr } = await execFile(binPath, args)
+      const { stdout, stderr } = await execFile('node', args)
       assert.strictEqual(stdout, `$ORIGIN example.com.
 $TTL 3600
 example.com.          3600  SOA    
@@ -55,10 +55,10 @@ mail3.example.com.    3600  A
 
   it('parses tinydns example data file to maradns', async function () {
     const binPath = path.resolve('bin', 'dns-zone.js')
-    const args = [ '-i', 'tinydns', '-f', './test/fixtures/tinydns/data', '-e', 'maradns' ]
+    const args = [ binPath, '-i', 'tinydns', '-f', './test/fixtures/tinydns/data', '-e', 'maradns' ]
     // console.log(`${binPath} ${args.join(' ')}`)
     try {
-      const { stdout, stderr } = await execFile(binPath, args)
+      const { stdout, stderr } = await execFile('node', args)
       assert.strictEqual(stdout, `theartfarm.com.\t SOA\tns3.theartfarm.com.\thostmaster.theartfarm.com.\t2022032700\t16384\t2048\t1048576\t2560 ~
 theartfarm.com.\t+14400\tNS\tns3.theartfarm.com. ~
 theartfarm.com.\t+14400\tNS\tns1.theartfarm.com. ~
@@ -112,10 +112,10 @@ bounce.theartfarm.com.\t+86400\tCNAME\tcustom-email-domain.stripe.com. ~
 
   it('parses maradns example data file to tinydns', async function () {
     const binPath = path.resolve('bin', 'dns-zone.js')
-    const args = [ '-i', 'maradns', '-f', './test/fixtures/mara/example.net.csv2', '--origin=example.net', '-e', 'tinydns' ]
+    const args = [ binPath, '-i', 'maradns', '-f', './test/fixtures/mara/example.net.csv2', '--origin=example.net', '-e', 'tinydns' ]
     // console.log(`${binPath} ${args.join(' ')}`)
     try {
-      const { stdout, stderr } = await execFile(binPath, args)
+      const { stdout, stderr } = await execFile('node', args)
       assert.strictEqual(stdout, `Zx.org:x.org:john\\.doe.x.org:2:7200:3600:604800:1800:86400::
 &example.net::a.example.net:86400::
 &example.net::b.example.net:86400::

--- a/test/dns-zone.js
+++ b/test/dns-zone.js
@@ -109,4 +109,58 @@ bounce.theartfarm.com.\t+86400\tCNAME\tcustom-email-domain.stripe.com. ~
       assert.ifError(e)
     }
   })
+
+  it('parses maradns example data file to tinydns', async function () {
+    const binPath = path.resolve('bin', 'dns-zone.js')
+    const args = [ '-i', 'maradns', '-f', './test/fixtures/mara/example.net.csv2', '--origin=example.net', '-e', 'tinydns' ]
+    // console.log(`${binPath} ${args.join(' ')}`)
+    try {
+      const { stdout, stderr } = await execFile(binPath, args)
+      assert.strictEqual(stdout, `Zx.org:x.org:john\\.doe.x.org:1651193101:7200:3600:604800:1800:86400::
+&example.net::a.example.net:86400::
+&example.net::b.example.net:86400::
+&example.net::ns1.example.net:86400::
+&example.net::ns2.example.net:86400::
++b.example.net:10.10.10.11:86400::
++b.example.net:10.10.10.12:86400::
++z.example.net:10.2.3.4:86400::
++y.example.net:10.3.4.5:86400::
++percent.example.net:10.9.8.7:86400::
++d.example.net:10.11.12.13:86400::
++f.example.net:10.2.19.83:86400::
++c.example.net:10.1.1.1:86400::
++e.example.net:10.2.3.4:86400::
++h.example.net:10.9.8.7:86400::
++g.example.net:10.11.9.8:86400::
+@example.net::mail.example.net:10:86400::
++mail.example.net:10.22.23.24:86400::
+:a.example.net:28:\\375\\115\\141\\162\\141\\104\\116\\123\\000\\001\\000\\002\\000\\003\\000\\004:86400::
+:_http._tcp.example.net:33:\\000\\000\\000\\000\\000\\120\\001a\\007example\\003net\\000:86400::
+'example.net:This is some text:86400::
+'example.com:This is an example text field:86400::
+:example.net:99:v=spf1 +mx a\\072colo.example.com\\05728 -all:86400::
+:example.com:99:v=spf1 +mx a\\072colo.example.com\\05728 \\134x7eall:86400::
++a.example.net:10.11.12.13:86400::
++b.example.net:10.11.12.14:86400::
++c.example.net:10.11.12.15:86400::
+^13.12.11.10.in-addr.arpa:a.example.net:86400::
+^14.12.11.10.in-addr.arpa:b.example.net:86400::
+^15.12.11.10.in-addr.arpa:c.example.net:86400::
+:www.example.com:35:\\000\\144\\000\\144\\001S\\010http+I2R\\000\\027_http._tcp.example.com.\\000:86400::
++x.example.net:10.3.28.79:86400::
+^79.28.3.10.in-addr.arpa:x.example.net:86400::
++x.example.net:10.3.28.80:86400::
+^80.28.3.10.in-addr.arpa:x.example.net:86400::
+:x.example.net:28:\\375\\115\\141\\162\\141\\104\\116\\123\\000\\000\\000\\013\\000\\014\\000\\015:86400::
+^d.0.0.0.c.0.0.0.b.0.0.0.0.0.0.0.3.5.e.4.4.4.1.6.2.7.1.6.d.4.d.f.ip6.arpa:x.example.net:86400::
+:x.example.net:28:\\375\\115\\141\\162\\141\\104\\116\\123\\000\\000\\000\\013\\000\\014\\000\\016:86400::
+^e.0.0.0.c.0.0.0.b.0.0.0.0.0.0.0.3.5.e.4.4.4.1.6.2.7.1.6.d.4.d.f.ip6.arpa:x.example.net:86400::
+:example.com:13:\\021Intel Pentium III\\020CentOS Linux 3.7:86400::
+`)
+      assert.strictEqual(stderr, '')
+    }
+    catch (e) {
+      assert.ifError(e)
+    }
+  })
 })

--- a/test/fixtures/bind/example.net
+++ b/test/fixtures/bind/example.net
@@ -1,0 +1,5 @@
+$ORIGIN example.net.
+$TTL 3600
+@  IN  SOA   a.ns hostmaster 2020091025 7200 3600 1209600 3600
+$INCLUDE included
+@  IN  NS    a.ns

--- a/test/fixtures/bind/included
+++ b/test/fixtures/bind/included
@@ -1,0 +1,3 @@
+@  IN  NS    b.ns
+@  IN  NS    ns.somewhere.example.com.
+@  IN  MX    10 mail

--- a/test/fixtures/mara/example.net.csv2
+++ b/test/fixtures/mara/example.net.csv2
@@ -7,7 +7,7 @@
 # This is a commented out record and disabled.
 
 #%  SOA % email@% 1 7200 3600 604800 1800 ~
-x.org. SOA x.org. john\.doe@x.org. /serial 7200 3600 604800 1800 ~
+x.org. SOA x.org. john\.doe@x.org. 2 7200 3600 604800 1800 ~
 #x.org. SOA x.org. email@x.org. /serial 7200 3600 604800 1800 ~
 
 # Second of all, csv2 zone files do not need authoritative NS records.

--- a/test/fixtures/mara/example.net.csv2
+++ b/test/fixtures/mara/example.net.csv2
@@ -88,11 +88,11 @@ example.com.    SPF 'v=spf1 +mx a:colo.example.com/28 '\x7e'all' ~
 
 a.example.net.        A     10.11.12.13 ~
 b.example.net.        A     10.11.12.14 ~
-c.example.net. +64000 A     10.11.12.15 ~
+c.example.net. +86400 A     10.11.12.15 ~
 
 13.12.11.10.in-addr.arpa.        PTR    a.example.net. ~
 14.12.11.10.in-addr.arpa.        PTR    b.example.net. ~
-15.12.11.10.in-addr.arpa. +64000 PTR    c.example.net. ~
+15.12.11.10.in-addr.arpa. +86400 PTR    c.example.net. ~
 
 www.example.com. NAPTR 100 100 's';'http+I2R';'' _http._tcp.example.com. ~
 

--- a/test/fixtures/tinydns/data
+++ b/test/fixtures/tinydns/data
@@ -1,0 +1,43 @@
+Ztheartfarm.com:ns3.theartfarm.com.:hostmaster.theartfarm.com:2022032700:16384:2048:1048576:2560:86400::
+&theartfarm.com::ns3.theartfarm.com.:14400::
+&theartfarm.com::ns1.theartfarm.com.:14400::
+&theartfarm.com::ns2.theartfarm.com.:14400::
+@theartfarm.com.::mail.theartfarm.com.:10:28800::
+'theartfarm.com.:v=spf1 include\072mx.theartfarm.com ip4\07269.64.153.131 ip4\072172.16.16.5 -all:86400::
++theartfarm.com.:66.128.51.172:28800::
+@www.theartfarm.com::mail.theartfarm.com.:10:28800::
+@dmarc.theartfarm.com::mail.theartfarm.com.:10:86400::
+'theartfarm.com.:stripe-verification=a5fd4f2f0595baed5ff34b5faa4fbbfe1a3c558edb5d3e1f79a1b47c17034045:86400::
++localhost.theartfarm.com:127.0.0.1:86400::
++ns1.theartfarm.com:192.48.85.147:86400::
++www.theartfarm.com:66.128.51.172:28800::
+Cart.theartfarm.com:mail.theartfarm.com.:86400::
+Cftp.theartfarm.com:www.theartfarm.com.:28800::
+Cpop.theartfarm.com:mail.theartfarm.com.:28800::
+Csmtp.theartfarm.com:mail.theartfarm.com.:28800::
+Cimap.theartfarm.com:mail.theartfarm.com.:28800::
+Cdns.theartfarm.com:dns.tnpi.net.:86400::
+Cwww2.theartfarm.com:ns2.theartfarm.com.:3600::
++ns2.theartfarm.com:66.128.51.172:28800::
+'mail.theartfarm.com:v=spf1 a -all:28800::
+'www.theartfarm.com:v=spf1 a mx ip4\072127.0.0.24 -all:86400::
++vhost0.theartfarm.com:66.128.51.173:86400::
++mail.theartfarm.com:66.128.51.165:28800::
+Ctoaster.theartfarm.com:mail.theartfarm.com.:3600::
++ns3.theartfarm.com:138.210.133.60:28800::
++lo.mail.theartfarm.com:127.0.0.6:86400::
+'mar2013._domainkey.theartfarm.com:v=DKIM1;p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5Q41fZ8CqpSgzSWpDY88oGq+bXKHdROGHmyjY6+b8qLUmdoHgpcaBUhL2zhZChvx5uayVJRV\057gWxPZtODsozOqPk6fl8Mn1VH1MBsuQdShnC0a\057Tcm8bPW0NE2viHysUamvL+X5Ea9H2GyVGKpe6rdKrmUiCzZyRYwTYqLvC9HhkTNWjR3TuP5mA2rmBO8IBPBFkdaz7WveNaiR8ImegA+wv1uCYcQLwcz3bn\057U2yK2UzFGsJLZ1KCTqr8WMPTuy1zc5zClHpZZMmCl3uk02bE59RVa7zzyZwVEGeRcjouq0rh5JCl057rMK2cwA2wu\057\0578svN+pGZAKJCnuFlpC0bwIDAQAB:3600::
+'_dmarc.theartfarm.com:v=DMARC1; p=reject; rua=mailto\072dmarc-feedback@theartfarm.com; ruf=mailto\072dmarc-feedback@theartfarm.com; pct=100:86400::
+'_dmarc.dmarc.theartfarm.com:v=DMARC1; p=reject; pct=100:86400::
+'dmarc.theartfarm.com:v=spf1 include\072mx.theartfarm.com -all:86400::
++dmarc.theartfarm.com:66.128.51.165:86400::
+'mx.theartfarm.com:v=spf1 ip4\07266.128.51.160\05727 ip4\072192.48.85.146\05729 ip4\072173.45.131.0\05727 ip4\072204.11.99.0\05727 ip6\0722605\0727900\07220\072a\072\072\05764 ip6\0722605\072ae00\072329\072\0720\05764 -all:86400::
+Chtpta.theartfarm.com:vhost0.theartfarm.com.:86400::
+'vhost0.theartfarm.com:v=spf1 include\072mx.theartfarm.com -all:86400::
+'ns3.theartfarm.com:v=spf1 a ip4\072138.210.133.60 ip4\07246.105.8.147 -all:86400::
+Cwordpress.theartfarm.com:www.theartfarm.com.:86400::
+'apr2019._domainkey.mail.theartfarm.com:v=DKIM1;p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoW91trHF9nBzY3DeFtauDbPbr904YNBgW7mh\0578s5Fcmsi3TPB1bSqyBcr2BjYGqCG1KPFBvs+IRZNMDgHJ4wMSdC+4Pt6wXkMJpElNg4DjuP7q2UALJsOQ\057H54VtH8TWVMOekmc4W3um8ZqxePGJkWd2UGV+YT00dR8jLne5d+9MXo3CayOe3L7rK9uEvm0u8dLYLJaTmPdKI+8LWEIuxC4KeRsaB\05710M7NIaR73C5wB0HlTOm7MQW3806rTdlFYpO9Rtx2uV3stqCIfUYK9qeGLJFXHjLxh0nki4ztVIZdPi9TkZnj+juS5k8GTADSGy7PWawUnbhjEDyd4JX5YxwIDAQAB:86400::
++ns1.theartfarm.com:173.45.131.5:86400::
++ns1.theartfarm.com:204.11.99.5:86400::
++mx-out.theartfarm.com:66.128.51.178:86400::
+Cbounce.theartfarm.com:custom-email-domain.stripe.com.:86400::

--- a/test/index.js
+++ b/test/index.js
@@ -17,4 +17,23 @@ describe('dns-zone', function () {
       assert.strictEqual(dz.hasUnquoted('this is a string "of ( quoted" text', '"', '('), false)
     })
   })
+
+  const cases = {
+    '1w2d3h4m5s': 788645,
+    '1w1d'      : 691200,
+    '1w'        : 604800,
+    '1d'        : 86400,
+    '2h'        : 7200,
+    '1m'        : 60,
+    '3600'      : 3600,
+    '4500s'     : 4500,
+  }
+
+  describe('toSeconds', function () {
+    for (const c in cases) {
+      it(`converts ${c} to ${cases[c]} seconds`, function () {
+        assert.equal(dz.toSeconds(c), cases[c])
+      })
+    }
+  })
 })

--- a/test/maradns.js
+++ b/test/maradns.js
@@ -1,6 +1,7 @@
 
 import assert from 'assert'
 import fs     from 'fs/promises'
+import os     from 'os'
 
 import * as RR from 'dns-resource-record'
 import mara from '../lib/maradns.js'
@@ -22,7 +23,7 @@ describe('maradns', function () {
 
     it('parses two blank lines', async () => {
       mara.zoneOpts.showBlank = true
-      const r = await mara.parseZoneFile(`\n`)
+      const r = await mara.parseZoneFile(os.EOL)
       // console.dir(r, { depth: null })
       assert.deepStrictEqual(r, [ '', '' ])
     })


### PR DESCRIPTION
- fix(dns-zone): update import syntax for ESM RR
- feat(bin/dns-zone): when -e=tinydns fails, show entry
- feat(bin/dns-zone): usage caller specifies exit code
- feat(bind): print a . for every 500 RRs parsed
- feat(bind): add $INCLUDE directive support, fixes #9 
- feat(tinydns): print unparsable line before throwing
- test(dns-zone): add help and example.com tests
- test(dns-zone): import tinydns zone, export as mara
- test(dns-zone): add to/from tiny/maradns tests