### PR TITLE
Release v1.1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,22 +15,28 @@ jobs:
     secrets: inherit
 
   test:
-    needs: lint
+    needs: get-lts
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        node-version: [ 14, 16, 18 ]
+        node-version: ${{ fromJson(needs.get-lts.outputs.active) }}
       fail-fast: false
-
     steps:
     - uses: actions/checkout@v3
-
     - uses: actions/setup-node@v3
       name: Node ${{ matrix.node-version }} on ${{ matrix.os }}
       with:
         node-version: ${{ matrix.node-version }}
-
     - run: npm install
-
     - run: npm test
+
+  get-lts:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - id: get
+        uses: msimerson/node-lts-versions@v1.3.1
+    outputs:
+      lts: ${{ steps.get.outputs.lts }}
+      active: ${{ steps.get.outputs.active }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ### Unreleased
 
 
+### [1.1.4] - 2022-06-03
+
+- ci: auto-populate node LTS versions for CI tests
+
+
 ### [1.1.3] - 2022-05-29
 
 - chore(ci): updated shared GHA workflow URLs
@@ -170,5 +175,7 @@
 - ci: remove windows support, times out, I think upstream nearley issue
 
 
+[1.1.1]: https://github.com/NicTool/dns-zone/releases/tag/1.1.1
 [1.1.2]: https://github.com/NicTool/dns-zone/releases/tag/1.1.2
 [1.1.3]: https://github.com/NicTool/dns-zone/releases/tag/1.1.3
+[1.1.4]: https://github.com/NicTool/dns-zone/releases/tag/1.1.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nictool/dns-zone",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "DNS Zone",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
- ci: auto-populate node LTS versions for CI tests
